### PR TITLE
Allow to set IO_CONTROL_2 register for bias voltage on AIN pins.

### DIFF
--- a/src/ad7124.cpp
+++ b/src/ad7124.cpp
@@ -220,6 +220,19 @@ Ad7124Chip::setCurrentSource (uint8_t source, uint8_t ch, IoutCurrent current) {
 
 // -----------------------------------------------------------------------------
 int
+Ad7124Chip::setBiasPins (uint16_t pinMask) {
+  Ad7124Register * r;
+
+  r = &reg[IOCon_2];
+  r->value &= 0xCC33;
+  
+  r->value |= pinMask;
+  
+  return writeRegister (IOCon_2);
+}
+
+// -----------------------------------------------------------------------------
+int
 Ad7124Chip::setAdcControl (OperatingMode mode,
                            PowerMode power_mode,
                            bool ref_en, ClkSel clk_sel) {

--- a/src/ad7124.h
+++ b/src/ad7124.h
@@ -329,6 +329,18 @@ class Ad7124Chip {
     int setCurrentSource (uint8_t source, uint8_t ch, Ad7124::IoutCurrent current);
 
     /**
+     * @brief Setting up bias voltage on AIN-Pins
+     *
+     * The AD7124 contains a bias voltage source. This source can be
+     * connected to each AIN-Pin of the AD7124.
+     *
+     * @param pinMask values for the IOCon_2 register (
+     *  AD7124(_8)_IO_CTRL2_REG_GPIO_VBIAS<pin>
+     * @return 0 for success or negative error code
+     */
+    int Ad7124Chip::setBiasPins (uint16_t pinMask);
+
+    /**
      * @brief Sampling a channel
      * The channel is enabled in single mode, then the conversion is started
      * and the value of the sample is returned

--- a/src/ad7124.h
+++ b/src/ad7124.h
@@ -338,7 +338,7 @@ class Ad7124Chip {
      *  AD7124(_8)_IO_CTRL2_REG_GPIO_VBIAS<pin>
      * @return 0 for success or negative error code
      */
-    int Ad7124Chip::setBiasPins (uint16_t pinMask);
+    int setBiasPins (uint16_t pinMask);
 
     /**
      * @brief Sampling a channel


### PR DESCRIPTION
Hi,

I needed the bias voltage on the CN0398 evalboard to read from a redox electrode.
The neccesary registers are not in the source code by now, so I tried to fix it.
But beware .. I'm not a programmer, but a mechatronic engineer - so please check twice, if the code does work for you (and others).

Kind regards,
Tasso