### PR TITLE
Added method to control the Bridge Power Switch

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -45,7 +45,7 @@ getData	KEYWORD2
 currentChannel	KEYWORD2
 internalCalibration	KEYWORD2
 toVoltage	KEYWORD2
-
+setPWRSW	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################

--- a/src/ad7124.cpp
+++ b/src/ad7124.cpp
@@ -220,6 +220,22 @@ Ad7124Chip::setCurrentSource (uint8_t source, uint8_t ch, IoutCurrent current) {
 
 // -----------------------------------------------------------------------------
 int
+Ad7124Chip::setPWRSW(bool enabled) {
+  Ad7124Register * r;
+
+  r = &reg[IOCon_1]; 
+
+  r->value &= ~ AD7124_IO_CTRL1_REG_PDSW;
+  
+  if (enabled == true) {
+    r->value |= AD7124_IO_CTRL1_REG_PDSW;
+  }
+ 
+  return writeRegister (IOCon_1);
+}
+
+// -----------------------------------------------------------------------------
+int
 Ad7124Chip::setBiasPins (uint16_t pinMask) {
   Ad7124Register * r;
 

--- a/src/ad7124.h
+++ b/src/ad7124.h
@@ -337,6 +337,17 @@ class Ad7124Chip {
     int setCurrentSource (uint8_t source, uint8_t ch, Ad7124::IoutCurrent current);
 
     /**
+     * @brief Set state of power switch pin
+     *
+     * The AD7124-4 contains a low side switch that can be used
+     * to control excitation power to a bridge circuit.
+     *
+     * @param enabled State to set switch to. enabled = closed
+     * @return 0 for success or negative error code
+     */
+    int setPWRSW(bool enabled) ;
+
+    /**
      * @brief Setting up bias voltage on AIN-Pins
      *
      * The AD7124 contains a bias voltage source. This source can be


### PR DESCRIPTION
Added method to control the Bridge Power Switch. The AD7124 contains a low side switch to control excitation power to bridge type sensors. I needed control of this for my application but that functionality seemed to be missing, so I added the required function.