### PR TITLE
Use BitOrder instead of uint8_t on SAMD chips

### DIFF
--- a/src/include/ad7124-driver.h
+++ b/src/include/ad7124-driver.h
@@ -17,6 +17,7 @@
 #define __AD7124_DRIVER_ARDUINO_H__
 /* ========================================================================== */
 #include "ad7124-defs.h"
+#include <SPI.h>
 
 /**
  * @class Ad7124Driver
@@ -85,7 +86,11 @@ class Ad7124Driver {
     
   private:
     uint32_t speedMaximum;
+#if defined(SAMD_SERIES)
+    BitOrder dataOrder;
+#else
     uint8_t dataOrder;
+#endif
     uint8_t dataMode;
 };
 /* ========================================================================== */


### PR DESCRIPTION
The library doesn't appear to compile using platformIO and a feather express m4 because the SPI library uses BitOrder instead of uint8_t.