### PR TITLE
Reset state variables after chip reset

### DIFF
--- a/src/ad7124-private.cpp
+++ b/src/ad7124-private.cpp
@@ -235,6 +235,10 @@ Ad7124Private::reset (void) {
     return ret;
   }
 
+  /* reset state varibles */  
+  isReady = false;
+  useCRC = AD7124_DISABLE_CRC;
+  
   /* Wait for the reset to complete */
   return waitToPowerOn (responseTimeout);
 }


### PR DESCRIPTION
When the chip initializes (before registers are written) CRC is disabled, we don't know if "isReady". Subsequent calls to init (which calls reset() ) should start from a clean state.